### PR TITLE
Use local Spark session and document Windows setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 OPENAI_API_KEY=your_openai_api_key
 # Optional: personas separadas por vírgula
 AGENT_PERSONAS=analista de pontualidade,gerente de operações
+# Opcional: caminhos para Spark e Hadoop (necessário no Windows)
+SPARK_HOME=/caminho/para/spark
+HADOOP_HOME=/caminho/para/hadoop

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Este projeto demonstra um pipeline ETL simples usando dados simulados de um aero
 - (Opcional) [PySpark](https://spark.apache.org/docs/latest/api/python/) para usar o Spark.
 - (Opcional) [LangChain](https://python.langchain.com/), [OpenAI](https://pypi.org/project/openai/) e [python-dotenv](https://pypi.org/project/python-dotenv/) para o agente baseado em LLM.
 
+> Em ambientes Windows, defina as variáveis de ambiente `SPARK_HOME` e `HADOOP_HOME` para evitar avisos sobre `winutils.exe`.
+
 Para instalar as dependências opcionais quando houver acesso à internet:
 
 ```bash

--- a/airport_etl.py
+++ b/airport_etl.py
@@ -136,7 +136,12 @@ class LangChainReactAgent:
 def main():
     spark = None
     if SPARK_AVAILABLE:
-        spark = SparkSession.builder.appName("AirportETL").getOrCreate()
+        spark = (
+            SparkSession.builder.master("local[*]")
+            .appName("AirportETL")
+            .getOrCreate()
+        )
+        spark.sparkContext.setLogLevel("ERROR")
     data = generate_simulated_data(spark)
     stats = transform_data(data, spark)
 


### PR DESCRIPTION
## Summary
- Configure SparkSession to run in local mode and cut down log noise
- Add SPARK_HOME and HADOOP_HOME placeholders to .env.example for Windows users
- Document Windows-specific environment variables in README

## Testing
- `python airport_etl.py`
- `python -m py_compile airport_etl.py`


------
https://chatgpt.com/codex/tasks/task_e_68965c9f04a4832bb6c1bddbdbdc104c